### PR TITLE
Fix display of prices

### DIFF
--- a/projects/cics-nodejs-invoke/public/assets/js/main.js
+++ b/projects/cics-nodejs-invoke/public/assets/js/main.js
@@ -45,7 +45,7 @@ function refreshItems(itemsLength,divToAppend) {
 
         var item_ref = allItemsJson[i].itemRef;
         var item_description = allItemsJson[i].itemDescription;
-        var item_cost = "£" + allItemsJson[i].itemCost.substring(2);
+        var item_cost = "£" + parseFloat(allItemsJson[i].itemCost).toFixed(2);
         var item_stock = "In Stock: " + allItemsJson[i].inStock;
         var item_maxnumber = allItemsJson[i].inStock;
 


### PR DESCRIPTION
When viewing an item, the price is returned from the host as a string.
The first two leading characters were removed.
This caused "025.99" to be displayed as "5.99".